### PR TITLE
Add initial database schema for chatbot and embeddings

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -2,7 +2,7 @@
 # https://supabase.com/docs/guides/local-development/cli/config
 # A string used to distinguish different Supabase projects on the same host. Defaults to the
 # working directory name when running `supabase init`.
-project_id = "starterkit"
+project_id = "oss-chatbot-with-rag"
 
 [api]
 enabled = true
@@ -20,6 +20,9 @@ max_rows = 1000
 [api.tls]
 # Enable HTTPS endpoints locally using a self-signed certificate.
 enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
 
 [db]
 # Port to use for the local database URL.
@@ -272,6 +275,8 @@ redirect_uri = ""
 url = ""
 # If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
 skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
 
 # Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
 # You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
@@ -301,15 +306,25 @@ enabled = false
 # Obtain from https://clerk.com/setup/supabase
 # domain = "example.clerk.accounts.dev"
 
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
 [edge_runtime]
 enabled = true
-# Configure one of the supported request policies: `oneshot`, `per_worker`.
-# Use `oneshot` for hot reload, or `per_worker` for load testing.
-policy = "oneshot"
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
 # Port to attach the Chrome inspector for debugging edge functions.
 inspector_port = 8083
 # The Deno major version to use.
-deno_version = 1
+deno_version = 2
 
 # [edge_runtime.secrets]
 # secret_key = "env(SECRET_VALUE)"

--- a/supabase/migrations/20251113102949_chatbot_schema.sql
+++ b/supabase/migrations/20251113102949_chatbot_schema.sql
@@ -1,0 +1,32 @@
+create extension if not exists vector;
+
+create table chat_sessions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users (id) on delete cascade,
+  title text,
+  created_at timestamp default now()
+);
+
+create table chat_messages (
+  id uuid primary key default gen_random_uuid(),
+  session_id uuid references chat_sessions (id) on delete cascade,
+  role text check (role in ('user', 'assistant')),
+  content text,
+  created_at timestamp default now()
+);
+
+create table chat_sources (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users (id) on delete cascade,
+  name text,
+  content text,
+  created_at timestamp default now()
+);
+
+create table chat_embeddings (
+  id uuid primary key default gen_random_uuid(),
+  source_id uuid references chat_sources (id) on delete cascade,
+  embedding vector(1536),
+  metadata jsonb,
+  created_at timestamp default now()
+);

--- a/supabase/migrations/20251113122423_enable_rls_and_policies.sql
+++ b/supabase/migrations/20251113122423_enable_rls_and_policies.sql
@@ -1,0 +1,49 @@
+-- Enable Row Level Security
+alter table chat_sessions enable row level security;
+alter table chat_messages enable row level security;
+alter table chat_sources enable row level security;
+alter table chat_embeddings enable row level security;
+
+-- Allow users to select/insert/update/delete only their own chat sessions
+create policy "Users can manage their own chat sessions"
+  on chat_sessions
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+-- Messages linked to user's sessions
+create policy "Users can manage messages in their sessions"
+  on chat_messages
+  for all
+  using (
+    session_id in (
+      select id from chat_sessions where user_id = auth.uid()
+    )
+  )
+  with check (
+    session_id in (
+      select id from chat_sessions where user_id = auth.uid()
+    )
+  );
+
+-- Sources belong to user
+create policy "Users can manage their own sources"
+  on chat_sources
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+-- Embeddings linked to user's sources
+create policy "Users can manage their own embeddings"
+  on chat_embeddings
+  for all
+  using (
+    source_id in (
+      select id from chat_sources where user_id = auth.uid()
+    )
+  )
+  with check (
+    source_id in (
+      select id from chat_sources where user_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
This pull request introduces a modular database schema designed for integrating chatbot functionality into existing projects without interfering with their existing schema.
The schema supports chat sessions, message storage, external data sources, and vector embeddings.
New Tables Added
1.	chat_sessions – Tracks individual user chat sessions.
o	Links to auth.users via user_id.
o	Includes session title and timestamps.
2.	chat_messages – Stores all messages exchanged within a chat session.
o	Includes role (user / assistant) and message content.
3.	chat_sources – Stores external data or document snippets associated with a user.
4.	chat_embeddings – Stores vector embeddings for semantic search / retrieval.
o	Uses pgvector extension (vector(1536) dimensions).
o	Includes metadata for additional context.
 
<img width="818" height="441" alt="Schema" src="https://github.com/user-attachments/assets/fc032021-05fb-451f-a8a4-e38833a0e989" />

Security & Policies
•	Row Level Security (RLS) enabled for all tables.
•	Policies ensure:
o	Users can only access their own sessions, messages, and sources.
o	Embeddings are isolated per user through foreign key relationships.

1.	This schema is linked with auth.users for authentication consistency.
2.	All migrations are defined under supabase/migrations/ for portability.
